### PR TITLE
support for getting ssl_protocol from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Firstly setup the `:ms_luis` config in your applications config file
 config :ms_luis, :config,
   url: "https://westus.api.cognitive.microsoft.com",
   app_key: "<your-application-key>",
-  sub_key: "<your-subscription-key>",
-  ssl_protocol: :"tlsv1.2"
+  sub_key: "<your-subscription-key>"
 ```
 
 Then you can call the `MsLuis.get_intent/1` function with the text you wish to get the intent for.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Firstly setup the `:ms_luis` config in your applications config file
 config :ms_luis, :config,
   url: "https://westus.api.cognitive.microsoft.com",
   app_key: "<your-application-key>",
-  sub_key: "<your-subscription-key>"
+  sub_key: "<your-subscription-key>",
+  ssl_protocol: :"tlsv1.2"
 ```
 
 Then you can call the `MsLuis.get_intent/1` function with the text you wish to get the intent for.

--- a/lib/ms_luis.ex
+++ b/lib/ms_luis.ex
@@ -2,6 +2,16 @@ defmodule MsLuis do
 
   @moduledoc """
   The `MsLuis` module is used to send requests to the LUIS service.
+
+  ## Configuration of SSL protocol
+  It is possible to override the default ssl_protocol using configuration
+
+  config :ms_luis, :config,
+    url: "https://westus.api.cognitive.microsoft.com",
+    app_key: "<your-application-key>",
+    sub_key: "<your-subscription-key>",
+    ssl_protocol: :"tlsv1.2"
+
   """
 
   @doc """

--- a/lib/ms_luis.ex
+++ b/lib/ms_luis.ex
@@ -32,7 +32,7 @@ defmodule MsLuis do
     opts = []
     
     with config             <- Application.get_env(:ms_luis, :config),
-	 {:ok, url}         <- build_url(config, query),
+         {:ok, url}         <- build_url(config, query),
          {:ok, merged_opts} <- build_opts(config, opts)
       do
       Ivar.new(:get, url, merged_opts)
@@ -40,7 +40,7 @@ defmodule MsLuis do
       |> Ivar.unpack
       |> respond
       else
-	err -> err
+        err -> err
     end
   end
 
@@ -65,9 +65,9 @@ defmodule MsLuis do
          {:ok, app_key} <- Keyword.fetch(config, :app_key),
          {:ok, sub_key} <- Keyword.fetch(config, :sub_key)
       do
-      {:ok, "#{url}/luis/v2.0/apps/#{app_key}?subscription-key=#{sub_key}&verbose=true&q=#{query}"}
+        {:ok, "#{url}/luis/v2.0/apps/#{app_key}?subscription-key=#{sub_key}&verbose=true&q=#{query}"}
       else
-	_ -> {:error, "There is a missing value in the config for :ms_luis"}
+        _ -> {:error, "There is a missing value in the config for :ms_luis"}
     end
   end
 

--- a/lib/ms_luis.ex
+++ b/lib/ms_luis.ex
@@ -5,13 +5,14 @@ defmodule MsLuis do
 
   ## Configuration of SSL protocol
   It is possible to override the default ssl_protocol using configuration
-
+  
+  ```
   config :ms_luis, :config,
     url: "https://westus.api.cognitive.microsoft.com",
     app_key: "<your-application-key>",
     sub_key: "<your-subscription-key>",
     ssl_protocol: :"tlsv1.2"
-
+  ```
   """
 
   @doc """

--- a/lib/ms_luis.ex
+++ b/lib/ms_luis.ex
@@ -1,4 +1,5 @@
 defmodule MsLuis do
+
   @moduledoc """
   The `MsLuis` module is used to send requests to the LUIS service.
   """
@@ -8,38 +9,55 @@ defmodule MsLuis do
   
   Args
   
-    * `query` - a binary that is to be sent to the LUIS service
+  * `query` - a binary that is to be sent to the LUIS service
 
   Usage
 
-      MsLuis.get_intent("turn off the lights")
-      # {:ok, %{"topScoringIntent" => "lights_off", ...}}
+  MsLuis.get_intent("turn off the lights")
+  # {:ok, %{"topScoringIntent" => "lights_off", ...}}
   """
   @spec get_intent(binary) :: {atom, map} | {:error, binary | atom}
   def get_intent(query) do
     query = URI.encode(query)
-
-    with config     <- Application.get_env(:ms_luis, :config),
-         {:ok, url} <- build_url(config, query)
-    do
-      Ivar.new(:get, url)
+    opts = []
+    
+    with config             <- Application.get_env(:ms_luis, :config),
+	 {:ok, url}         <- build_url(config, query),
+         {:ok, merged_opts} <- build_opts(config, opts)
+      do
+      Ivar.new(:get, url, merged_opts)
       |> Ivar.send
       |> Ivar.unpack
       |> respond
-    else
-      err -> err
+      else
+	err -> err
     end
   end
 
+
+  defp build_ssl_protocol_string(version) do
+    default_protocol = :"tlsv1.2"
+    [ssl: [{:versions, [version || default_protocol]}]]
+  end
+
+  defp build_opts(nil, _), do: {:error, "No config found for :ms_luis"}
+  defp build_opts(config, opts) do
+    merged_opts = config[:ssl_protocol]
+    |> build_ssl_protocol_string()
+    |> Keyword.merge(opts)
+
+    {:ok, merged_opts}
+  end
+  
   defp build_url(nil, _), do: {:error, "No config found for :ms_luis"}
   defp build_url(config, query) do
     with {:ok, url}     <- Keyword.fetch(config, :url),
          {:ok, app_key} <- Keyword.fetch(config, :app_key),
          {:ok, sub_key} <- Keyword.fetch(config, :sub_key)
-    do
+      do
       {:ok, "#{url}/luis/v2.0/apps/#{app_key}?subscription-key=#{sub_key}&verbose=true&q=#{query}"}
-    else
-      _ -> {:error, "There is a missing value in the config for :ms_luis"}
+      else
+	_ -> {:error, "There is a missing value in the config for :ms_luis"}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule MsLuis.Mixfile do
 
   defp deps do
     [
-      {:ivar, "~> 0.3.0"},
+      {:ivar, "~> 0.7.0"},
       {:poison, "~> 3.0"},
 
       # dev deps


### PR DESCRIPTION
Took a stab at a combo of using config and using a default. It will look for the ssl_protocol in the config (see README changes) and use it if found, otherwise it will default to tlsv1.2. 

__Note:__ the use of opts = [] in get_intent() is there in case in the future you want to allow options to be passed in like you did with your ivar module. 